### PR TITLE
Invisible genitals for taurs, for hermaphrodites, for everyone (I swear I'm doing this for my best friend)

### DIFF
--- a/code/modules/arousal/genitals_sprite_accessories.dm
+++ b/code/modules/arousal/genitals_sprite_accessories.dm
@@ -72,6 +72,9 @@
 	icon_state = "sheath"
 	name = "Sheath"
 
+/datum/sprite_accessory/testicles/disguised
+	name = "Inconspicuous pair of testicles"
+
 //Vaginas
 /datum/sprite_accessory/vagina
 	icon = 'icons/obj/genitals/vagina_onmob.dmi'

--- a/code/modules/arousal/genitals_sprite_accessories.dm
+++ b/code/modules/arousal/genitals_sprite_accessories.dm
@@ -110,6 +110,10 @@
 	icon_state = "gaping"
 	name = "Gaping"
 
+/datum/sprite_accessory/vagina/inconspicuous
+	name = "Inconspicuous"
+	alt_aroused = FALSE
+
 //BREASTS BE HERE
 /datum/sprite_accessory/breasts
 	icon = 'icons/obj/genitals/breasts_onmob.dmi'

--- a/code/modules/arousal/organs/vagina.dm
+++ b/code/modules/arousal/organs/vagina.dm
@@ -19,7 +19,7 @@
 	var/clits = 1
 	var/clit_diam = 0.25
 	var/clit_len = 0.25
-	var/list/vag_types = list("tentacle", "dentata", "hairy", "spade", "furred")
+	var/list/vag_types = list("tentacle", "dentata", "hairy", "spade", "furred", "inconspicuous")
 	associated_has = CS_VAG // for cockstring stuff
 	hide_flag = HIDE_VAG // for hideflag stuff
 
@@ -44,6 +44,8 @@
 			details = "It is a plush canine spade, it "
 		if("furred")
 			details = "It has neatly groomed fur around the outer folds, it "
+		if("inconspicuous")
+			details = "It is taut with smooth skin, and it "
 		else
 			details = "It has an exotic shape and "
 	if(aroused_state)


### PR DESCRIPTION
## About The Pull Request
Simply adds the option to have an inconspicuous pair of testicles or vagina. (what has my life become...) Basically a friend brought an issue up with taur sprites and exposed genitals, it makes sense that some of these bits are- exposed on the lower half of the taur. Spriting them wouldn't really be worth it as they may as well be hidden by thighs, tail etc... 
So.. these are two invisible bits that simply give the examiner some flavour text but cannot be seen.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: two new lewd genital options.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
